### PR TITLE
Error de precarga de CSS

### DIFF
--- a/source/javascripts/menu_proyectos.js
+++ b/source/javascripts/menu_proyectos.js
@@ -3,6 +3,10 @@ const $botonAbrirMenuProyectos = document.getElementById("boton-menu-proyectos")
 const $menuProyectos = document.getElementById("menu-proyectos");
 const $body = document.getElementsByTagName("body")[0];
 
+window.addEventListener("load", () => {
+  toggleClassOnElement($body, ["preload"]);
+});
+
 $botonCerrarMenuProyectos.addEventListener("click", () => {
   $body.removeAttribute("style");
   toggleClassOnElement($menuProyectos, ["t-ty-0px", "t-ty--100pt"]);

--- a/source/layouts/inicio.erb
+++ b/source/layouts/inicio.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_tag "index" %>
     <%= partial "partials/favicons" %>
   </head>
-  <body class="h-100pt d-flex fd-column">
+  <body class="h-100pt d-flex fd-column preload">
     <%= partial "partials/header" %>
     <%= partial "partials/proyectos" %>
     <main class="d-flex ai-center f-1 jc-center-m">

--- a/source/layouts/principal.erb
+++ b/source/layouts/principal.erb
@@ -10,7 +10,7 @@
     <%= stylesheet_link_tag "index" %>
     <%= partial "partials/favicons" %>
   </head>
-  <body class="h-100pt-m d-flex-m fd-column-m">
+  <body class="h-100pt-m d-flex-m fd-column-m preload">
     <%= partial "partials/header" %>
     <%= partial "partials/proyectos" %>
     <main class="d-flex ai-center f-1-m jc-center-m">

--- a/source/layouts/proyectos.erb
+++ b/source/layouts/proyectos.erb
@@ -11,7 +11,7 @@
     <%= stylesheet_link_tag "index" %>
     <%= partial "partials/favicons" %>
   </head>
-  <body class="d-flex-m fd-column-m oy-hidden-m h-100pt-m m-0px-m p-0px-m">
+  <body class="d-flex-m fd-column-m oy-hidden-m h-100pt-m m-0px-m p-0px-m preload">
     <%= partial "partials/header" %>
     <%= partial "partials/proyectos" %>
     <main class="mb-48px pt-24px ph-24px oy-hidden-m d-flex-m f-1-m m-0px-m p-0px-m">

--- a/source/stylesheets/index.css
+++ b/source/stylesheets/index.css
@@ -184,11 +184,19 @@
 /*
 
   TRANSITIONS
+  - Preload
   - Transition property
   - Transition timing function
   - Transition duration
 
 */
+/* Preload */
+.preload * {
+  -webkit-transition: none !important;
+  -moz-transition: none !important;
+  -ms-transition: none !important;
+  -o-transition: none !important;
+}
 /* Transition property */
 .tp-max_height { transition-property: max-height; }
 .tp-transform { transition-property: transform; }


### PR DESCRIPTION
* Arreglando la precarga de CSS con `preload`
* Agregando la clase de `.preload` a el `body` de todos los layouts
* Creando una función que quita la clase de `.preload` del `body` una vez cargada la ventana
* Creando una clase de `.preload` para prevenir que las transiciones de CSS se ejecuten antes de que la ventana esté cargada